### PR TITLE
initial changes to tap_quickbase

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ or
 ```bash
 $ git clone git@github.com:flash716/tap-quickbase.git
 $ cd tap-quickbase
-$ mkvirtualenv -p python tap-quickbase
-$ python install .
+$ mkvirtualenv -p python3 tap-quickbase
+$ cd tap-quickbase
+$ pip install .
 ```
 
 
@@ -117,7 +118,7 @@ description of each table. A source table directly corresponds to a Singer strea
       "metadata": [
         {
           "metadata": {
-            "id": "1"
+            "tap-quickbase.id": "1"
           },
           "breadcrumb": [
             "properties",
@@ -126,7 +127,7 @@ description of each table. A source table directly corresponds to a Singer strea
         },
         {
           "metadata": {
-            "id": "2"
+            "tap-quickbase.id": "2"
           },
           "breadcrumb": [
             "properties",
@@ -135,7 +136,7 @@ description of each table. A source table directly corresponds to a Singer strea
         },
         {
           "metadata": {
-            "id": "6"
+            "tap-quickbase.id": "6"
           },
           "breadcrumb": [
             "properties",
@@ -219,7 +220,7 @@ The stream's schema gets a top-level `selected` flag, as does its columns' schem
       "metadata": [
         {
           "metadata": {
-            "id": "1"
+            "tap-quickbase.id": "1"
           },
           "breadcrumb": [
             "properties",
@@ -228,7 +229,7 @@ The stream's schema gets a top-level `selected` flag, as does its columns' schem
         },
         {
           "metadata": {
-            "id": "2"
+            "tap-quickbase.id": "2"
           },
           "breadcrumb": [
             "properties",
@@ -237,7 +238,7 @@ The stream's schema gets a top-level `selected` flag, as does its columns' schem
         },
         {
           "metadata": {
-            "id": "6"
+            "tap-quickbase.id": "6"
           },
           "breadcrumb": [
             "properties",

--- a/tests/test_tap.py
+++ b/tests/test_tap.py
@@ -71,7 +71,7 @@ class TestDiscoverCatalog(unittest.TestCase):
         for meta in self.catalog.streams[0].metadata:
             if tuple(meta['breadcrumb']) == ("properties", "datecreated", ):
                 found_breadcrumb = True
-                self.assertEqual("1", meta['metadata']['id'])
+                self.assertEqual("1", meta['metadata']['tap-quickbase.id'])
         self.assertTrue(found_breadcrumb)
 
 


### PR DESCRIPTION
A few changes for the initial version:
- Change replication key from 'last_record' to 'date modified' to keep it consistent with the field name
- Change the metadata field from 'id' to 'tap-quickbase.id' to ensure it is ignored by other layers in the pipeline.  
- Added 'time_extracted' to record messages, and 'bookmark_properties' to schema messages for better transparency.  
- Removed a few schema/state writes to reduce redundancy.  
- Changed to use Incremental replication