### PR TITLE
Fix duplicate field names

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-quickbase',
-      version='0.1.0',
+      version='0.9.4',
       description='Singer.io tap for extracting data from QuickBase',
       author='Stitch',
       url='https://singer.io',

--- a/tap_quickbase/__init__.py
+++ b/tap_quickbase/__init__.py
@@ -70,9 +70,18 @@ def discover_catalog(conn):
         )
         metadata = []
 
-        for field in conn.get_fields(table.get('id')):
+        table_fields = conn.get_fields(table.get('id'))
+        table_fields.sort(key=lambda field: int(field.get('id')))
+        table_fields_lookup = {}
+        for field in table_fields:
             field_type = ['null']
             field_format = None
+            field_name = field.get('name')
+
+            # if we have a parentFieldID grab the name of that field and add it to the field name to assure uniqueness
+            # since the fields are sorted by id we will have already processed the parent field
+            if field.get('parent_field_id'):
+                field_name = "{} - {}".format(table_fields_lookup.get(field.get('parent_field_id')), field_name)
 
             # https://help.quickbase.com/user-assistance/field_types.html
             if field.get('base_type') == 'bool':
@@ -100,7 +109,7 @@ def discover_catalog(conn):
             )
             if field_format is not None:
                 property_schema.format = field_format
-            schema.properties[field.get('name')] = property_schema
+            schema.properties[field_name] = property_schema
 
             metadata.append({
                 'metadata': {
@@ -108,9 +117,11 @@ def discover_catalog(conn):
                 },
                 'breadcrumb': [
                     'properties',
-                    field.get('name')
+                    field_name
                 ]
             })
+
+            table_fields_lookup[field.get('id')] = field_name
 
         entry = CatalogEntry(
             database=conn.appid,

--- a/tap_quickbase/__init__.py
+++ b/tap_quickbase/__init__.py
@@ -20,10 +20,12 @@ DATETIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
 CONFIG = {}
 STATE = {}
 NUM_RECORDS = 500
-
 LOGGER = singer.get_logger()
-
 REPLICATION_KEY = 'date modified'
+
+
+def format_child_field_name(parent_name, child_name):
+    return "{} -> {}".format(parent_name, child_name)
 
 def build_state(raw_state, catalog):
     LOGGER.info(
@@ -81,7 +83,7 @@ def discover_catalog(conn):
             # if we have a parentFieldID grab the name of that field and add it to the field name to assure uniqueness
             # since the fields are sorted by id we will have already processed the parent field
             if field.get('parent_field_id'):
-                field_name = "{} - {}".format(table_fields_lookup.get(field.get('parent_field_id')), field_name)
+                field_name = format_child_field_name(table_fields_lookup.get(field.get('parent_field_id')), field_name)
 
             # https://help.quickbase.com/user-assistance/field_types.html
             if field.get('base_type') == 'bool':

--- a/tap_quickbase/qbconn.py
+++ b/tap_quickbase/qbconn.py
@@ -100,5 +100,6 @@ class QBConn:
                 'name': name,
                 'type': remote_field.attrib['field_type'],
                 'base_type': remote_field.attrib['base_type'],
+                'parent_field_id': remote_field.find('parentFieldID'),
             })
         return fields

--- a/tap_quickbase/qbconn.py
+++ b/tap_quickbase/qbconn.py
@@ -95,11 +95,16 @@ class QBConn:
         for remote_field in remote_fields:
             name = remote_field.find('label').text.lower().replace('"', "'")
             name = COLUMN_NAME_TRANSLATION.sub('', name)
+            parent_field_id_element = remote_field.find('parentFieldID')
+            if parent_field_id_element is not None:
+                parent_field_id = parent_field_id_element.text
+            else:
+                parent_field_id = ""
             fields.append({
                 'id': remote_field.attrib['id'],
                 'name': name,
                 'type': remote_field.attrib['field_type'],
                 'base_type': remote_field.attrib['base_type'],
-                'parent_field_id': remote_field.find('parentFieldID'),
+                'parent_field_id': parent_field_id,
             })
         return fields

--- a/tests/mock_connection.py
+++ b/tests/mock_connection.py
@@ -18,30 +18,42 @@ class MockConnection():
                 'name': 'datecreated',
                 'type': 'timestamp',
                 'base_type': 'int64',
+                'parent_field_id': '',
             },
             {
                 'id': '2',
                 'name': 'datemodified',
                 'type': 'timestamp',
                 'base_type': 'int64',
+                'parent_field_id': '',
             },
             {
                 'id': '3',
                 'name': 'text_field',
                 'type': 'text',
                 'base_type': 'text',
+                'parent_field_id': '',
             },
             {
                 'id': '4',
                 'name': 'boolean_field',
                 'type': 'checkbox',
                 'base_type': 'bool',
+                'parent_field_id': '',
             },
             {
                 'id': '5',
                 'name': 'float_field',
                 'type': 'float',
                 'base_type': 'float',
+                'parent_field_id': '',
+            },
+            {
+                'id': '6',
+                'name': 'child_text_field',
+                'type': 'text',
+                'base_type': 'float',
+                'parent_field_id': '3',
             },
         ]}
         return fields[table_id]

--- a/tests/test_tap.py
+++ b/tests/test_tap.py
@@ -76,7 +76,7 @@ class TestDiscoverCatalog(unittest.TestCase):
 
     def test_child_field(self):
         self.assertTrue(
-            "text_field - child_text_field" in self.catalog.streams[0].schema.properties
+            tap_quickbase.format_child_field_name("text_field", "child_text_field") in self.catalog.streams[0].schema.properties
         )
 
 

--- a/tests/test_tap.py
+++ b/tests/test_tap.py
@@ -74,6 +74,11 @@ class TestDiscoverCatalog(unittest.TestCase):
                 self.assertEqual("1", meta['metadata']['tap-quickbase.id'])
         self.assertTrue(found_breadcrumb)
 
+    def test_child_field(self):
+        self.assertTrue(
+            "text_field - child_text_field" in self.catalog.streams[0].schema.properties
+        )
+
 
 class TestBuildFieldList(unittest.TestCase):
 


### PR DESCRIPTION
This PR addresses the issue with calculated child fields having duplicate names in the target table description. It appears that these fields are mostly sub-address fields like city, street, country, etc.

Child fields are now renamed as such:
`child_field_name`
to
`parent_field_name -> child_field_name`
