### PR TITLE
Change number of records per batch from 500 to 100

### DIFF
--- a/tap_quickbase/__init__.py
+++ b/tap_quickbase/__init__.py
@@ -19,7 +19,7 @@ REQUIRED_CONFIG_KEYS = ['qb_url', 'qb_appid', 'qb_user_token', 'start_date']
 DATETIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
 CONFIG = {}
 STATE = {}
-NUM_RECORDS = 500
+NUM_RECORDS = 100
 LOGGER = singer.get_logger()
 REPLICATION_KEY = 'date modified'
 


### PR DESCRIPTION
Should avoid `error code 75` errors when requesting large tables. I do not believe we need to worry about this speeding up the request rate and causing errors because we're internally enforcing a rate limit using `@singer.utils.ratelimit(2, 1)`