### PR TITLE
Providing Quickbase's errors from API

### DIFF
--- a/tap_quickbase/qbconn.py
+++ b/tap_quickbase/qbconn.py
@@ -48,8 +48,8 @@ class QBConn:
             if self.error_code != 0:
                 error = tree.find('errdetail')
                 error = tree.find('errtext') if error is None else error # XML nodes are falsy, so must explicitly check for None
-                self.error =  error.text if error is not None else "No error description provided by Quickbase."
-                raise Exception("Error response from Quickbase (Code {}): {}".format(self.error_code, self.error))
+                self.error =  error.text if error is not None else "No error description provided by Quick Base."
+                raise Exception("Error response from Quick Base (Code {}): {}".format(self.error_code, self.error))
             return tree
 
     def query(self, table_id, query, headers=None):

--- a/tap_quickbase/qbconn.py
+++ b/tap_quickbase/qbconn.py
@@ -44,7 +44,12 @@ class QBConn:
             self.error = -1
         else:
             tree = ElementTree.fromstring(resp.content)
-            self.error = int(tree.find('errcode').text)
+            self.error_code = int(tree.find('errcode').text)
+            if self.error_code != 0:
+                error = tree.find('errdetail')
+                error = tree.find('errtext') if error is None else error # XML nodes are falsy, so must explicitly check for None
+                self.error =  error.text if error is not None else "No error description provided by Quickbase."
+                raise Exception("Error response from Quickbase (Code {}): {}".format(self.error_code, self.error))
             return tree
 
     def query(self, table_id, query, headers=None):


### PR DESCRIPTION
Quick Base returns 200 status codes from their API with a description of the error either in an `errdetail` or `errtext` XML node.

If the `errcode` field is non-zero, this indicates an error and will stop the tap from executing with a description of what went wrong from the Quick Base response.