### PR TITLE
Using catalog fields and metadata in line with the singer spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ found as well as a default start_date to begin pulling data from.
 **Discovery mode**
 
 The tap can be invoked in discovery mode to find the available tables and columns 
-in the database.
+in the app's data.
 
 ```bash
 $ tap-quickbase --config config.tap.json --discover > properties.json
@@ -76,11 +76,10 @@ description of each table. A source table directly corresponds to a Singer strea
       "key_properties": [
         "rid"
       ],
-      "database_name": "database_id",
       "stream_alias": "table_name",
       "table_name": "table_id",
-      "tap_stream_id": "database_name__table_name",
-      "stream": "database_name__table_name",
+      "tap_stream_id": "app_name__table_name",
+      "stream": "app_name__table_name",
       "schema": {
         "properties": {
           "rid": {
@@ -116,6 +115,12 @@ description of each table. A source table directly corresponds to a Singer strea
         }
       },
       "metadata": [
+        {
+          "metadata": {
+            "tap-quickbase.app_id": app_id
+          },
+          "breadcrumb": []
+        },
         {
           "metadata": {
             "tap-quickbase.id": "1"
@@ -174,11 +179,10 @@ The stream's schema gets a top-level `selected` flag, as does its columns' schem
       "key_properties": [
         "rid"
       ],
-      "database_name": "database_id",
       "stream_alias": "table_name",
       "table_name": "table_id",
-      "tap_stream_id": "database_name__table_name",
-      "stream": "database_name__table_name",
+      "tap_stream_id": "app_name__table_name",
+      "stream": "app_name__table_name",
       "schema": {
         "properties": {
           "rid": {

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ description of each table. A source table directly corresponds to a Singer strea
       "metadata": [
         {
           "metadata": {
-            "tap-quickbase.app_id": app_id
+            "tap-quickbase.app_id": "app_id"
           },
           "breadcrumb": []
         },

--- a/tap_quickbase/__init__.py
+++ b/tap_quickbase/__init__.py
@@ -166,7 +166,7 @@ def discover_catalog(conn):
             },
             {
                 'metadata': {
-                    'tap_quickbase.app_id': conn.appid
+                    'tap-quickbase.app_id': conn.appid
                 },
                 'breadcrumb': []
             }
@@ -379,7 +379,7 @@ def get_start(table_id, state):
 def sync_table(conn, catalog_entry, state):
     metadata = singer_metadata.to_map(catalog_entry.metadata)
     LOGGER.info("Beginning sync for {}.{} table.".format(
-        singer_metadata.get(metadata, tuple(), "tap_quickbase.app_id"), catalog_entry.table
+        singer_metadata.get(metadata, tuple(), "tap-quickbase.app_id"), catalog_entry.table
     ))
 
     entity = catalog_entry.tap_stream_id
@@ -393,7 +393,7 @@ def sync_table(conn, catalog_entry, state):
     }
 
     with metrics.record_counter(None) as counter:
-        counter.tags['app'] = singer_metadata.get(metadata, tuple(), "tap_quickbase.app_id")
+        counter.tags['app'] = singer_metadata.get(metadata, tuple(), "tap-quickbase.app_id")
         counter.tags['table'] = catalog_entry.table
 
         extraction_time = singer_utils.now()
@@ -435,7 +435,7 @@ def generate_messages(conn, catalog, state):
         metadata = singer_metadata.to_map(catalog_entry.metadata)
         # Emit a RECORD message for each record in the result set
         with metrics.job_timer('sync_table') as timer:
-            timer.tags['app'] = singer_metadata.get(metadata, tuple(), "tap_quickbase.app_id")
+            timer.tags['app'] = singer_metadata.get(metadata, tuple(), "tap-quickbase.app_id")
             timer.tags['table'] = catalog_entry.table
             for message in sync_table(conn, catalog_entry, state):
                 yield message

--- a/tap_quickbase/__init__.py
+++ b/tap_quickbase/__init__.py
@@ -264,12 +264,17 @@ def build_field_lists(schema, metadata, breadcrumb):
         breadcrumb.extend(['properties', name])
 
         field_id = singer_metadata.get(metadata, tuple(breadcrumb), 'tap-quickbase.id')
-        if field_id and (sub_schema.selected or sub_schema.inclusion == 'automatic'):
+        selected = singer_metadata.get(metadata, tuple(breadcrumb), 'selected')
+        inclusion = singer_metadata.get(metadata, tuple(breadcrumb), 'inclusion')
+        if field_id and (selected or inclusion == 'automatic'):
             field_list.append(field_id)
             ids_to_breadcrumbs[field_id] = [i for i in breadcrumb]
-        elif sub_schema.properties and (sub_schema.selected or sub_schema.inclusion == 'automatic'):
+        elif sub_schema.properties and (selected or inclusion == 'automatic'):
             for name, child_schema in sub_schema.properties.items():
-                child_schema.selected = True
+                breadcrumb.extend(['properties', name]) # Select children of objects
+                metadata = singer_metadata.write(metadata, tuple(breadcrumb), 'selected', True)
+                breadcrumb.pop()
+                breadcrumb.pop()
             sub_field_list, sub_ids_to_breadcrumbs = build_field_lists(sub_schema, metadata, breadcrumb)
             field_list.extend(sub_field_list)
             ids_to_breadcrumbs.update(sub_ids_to_breadcrumbs)

--- a/tap_quickbase/qbconn.py
+++ b/tap_quickbase/qbconn.py
@@ -81,7 +81,7 @@ class QBConn:
         params = {'act': 'API_GetSchema'}
         schema = self.request(params, self.appid)
         remote_tables = schema.find('table').find('chdbids')
-        database_name = schema.find('table').find('name').text
+        app_name = schema.find('table').find('name').text
         tables = []
         if remote_tables is None:
             raise Exception("Error discovering streams: The specified application contains no tables.")
@@ -89,8 +89,8 @@ class QBConn:
             tables.append({
                 'id': remote_table.text,
                 'name': remote_table.attrib['name'][6:],
-                'database_name': database_name,
-                'database_id': self.appid
+                'app_name': app_name,
+                'app_id': self.appid
             })
         return tables
 

--- a/tests/mock_connection.py
+++ b/tests/mock_connection.py
@@ -1,59 +1,67 @@
 class MockConnection():
-    appid = "database_id"
+    appid = "app_id"
 
     def get_tables(self):
         return [
             {
                 'id': '1',
                 'name': 'table_name',
-                'database_name': 'database_name',
-                'database_id': 'database_id',
+                'app_name': 'app_name',
+                'app_id': 'app_id',
             }
         ]
 
     def get_fields(self, table_id):
-        fields = {'1': [
-            {
+        fields = {'1': {
+            '1': {
                 'id': '1',
                 'name': 'datecreated',
                 'type': 'timestamp',
                 'base_type': 'int64',
                 'parent_field_id': '',
             },
-            {
+            '2': {
                 'id': '2',
                 'name': 'datemodified',
                 'type': 'timestamp',
                 'base_type': 'int64',
                 'parent_field_id': '',
             },
-            {
+            '3': {
                 'id': '3',
                 'name': 'text_field',
                 'type': 'text',
                 'base_type': 'text',
                 'parent_field_id': '',
             },
-            {
+            '4': {
                 'id': '4',
                 'name': 'boolean_field',
                 'type': 'checkbox',
                 'base_type': 'bool',
                 'parent_field_id': '',
             },
-            {
+            '5': {
                 'id': '5',
                 'name': 'float_field',
                 'type': 'float',
                 'base_type': 'float',
                 'parent_field_id': '',
             },
-            {
+            '6': {
                 'id': '6',
                 'name': 'child_text_field',
                 'type': 'text',
                 'base_type': 'float',
-                'parent_field_id': '3',
+                'parent_field_id': '7',
             },
-        ]}
+            '7': {
+                'id':'7',
+                'name': 'parent_field',
+                'type': 'text',
+                'base_type': 'text',
+                'parent_field_id': '',
+                'composite_fields': ['6'],
+            }
+        }}
         return fields[table_id]


### PR DESCRIPTION
The tap was using a part of the catalog spec that is reserved for databases, this could cause some confusion in the UI of a wrapper that respects the database designation and renders the catalog differently.

To maintain metrics reporting under the same names, I'm moving this property to custom tap metadata under `tap_quickbase.app_id`