### PR TITLE
Update regex to remove any non-alphanumeric or underscore field

### DIFF
--- a/tap_quickbase/__init__.py
+++ b/tap_quickbase/__init__.py
@@ -21,7 +21,7 @@ CONFIG = {}
 STATE = {}
 NUM_RECORDS = 100
 LOGGER = singer.get_logger()
-REPLICATION_KEY = 'datemodified'
+REPLICATION_KEY = qbconn.sanitize_field_name('date modified')
 
 DEBUG_FLAG = False
 

--- a/tap_quickbase/__init__.py
+++ b/tap_quickbase/__init__.py
@@ -21,7 +21,7 @@ CONFIG = {}
 STATE = {}
 NUM_RECORDS = 100
 LOGGER = singer.get_logger()
-REPLICATION_KEY = 'date modified'
+REPLICATION_KEY = 'datemodified'
 
 DEBUG_FLAG = False
 

--- a/tap_quickbase/qbconn.py
+++ b/tap_quickbase/qbconn.py
@@ -6,7 +6,11 @@ import requests
 
 # This regex is used to transform the column name in `get_fields`
 COLUMN_NAME_TRANSLATION = re.compile(r"[^a-zA-Z0-9_]")
+UNDERSCORE_CONSOLIDATION = re.compile(r"_+")
 
+def sanitize_field_name(name):
+    result = COLUMN_NAME_TRANSLATION.sub('_', name)
+    return UNDERSCORE_CONSOLIDATION.sub('_', result)
 
 class QBConn:
     """
@@ -103,8 +107,7 @@ class QBConn:
         id_to_field = {}
         field_to_ids = {}
         for remote_field in remote_fields:
-            name = remote_field.find('label').text.lower().replace('"', "'")
-            name = COLUMN_NAME_TRANSLATION.sub('', name)
+            name = sanitize_field_name(remote_field.find('label').text.lower().replace('"', "'"))
             id_num =  remote_field.attrib['id']
             if field_to_ids.get(name):
                 field_to_ids[name].append(id_num)

--- a/tap_quickbase/qbconn.py
+++ b/tap_quickbase/qbconn.py
@@ -5,12 +5,15 @@ import re
 import requests
 
 # This regex is used to transform the column name in `get_fields`
+SEPARATORS_TRANSLATION = re.compile(r"[-\s]")
 COLUMN_NAME_TRANSLATION = re.compile(r"[^a-zA-Z0-9_]")
 UNDERSCORE_CONSOLIDATION = re.compile(r"_+")
 
 def sanitize_field_name(name):
-    result = COLUMN_NAME_TRANSLATION.sub('_', name)
-    return UNDERSCORE_CONSOLIDATION.sub('_', result)
+    result = name.lower()
+    result = SEPARATORS_TRANSLATION.sub('_', result) # Replace separator characters with underscores
+    result = COLUMN_NAME_TRANSLATION.sub('', result) # Remove all other non-alphanumeric characters
+    return UNDERSCORE_CONSOLIDATION.sub('_', result) # Consolidate consecutive underscores
 
 class QBConn:
     """

--- a/tap_quickbase/qbconn.py
+++ b/tap_quickbase/qbconn.py
@@ -4,7 +4,8 @@ import logging
 import re
 import requests
 
-COLUMN_NAME_TRANSLATION = re.compile(r"[^a-z0-9_ $!#%&'()*+,-./:;<=>?@[\]^~]")
+# This regex is used to transform the column name in `get_fields`
+COLUMN_NAME_TRANSLATION = re.compile(r"[^a-zA-Z0-9_]")
 
 
 class QBConn:


### PR DESCRIPTION
Since Quick Base allows any character in field names, but the destination of the data produced by this tap may not support all characters, this PR proposes removing any characters that could be an issue down the line.

Only alphanumeric and underscores will be permitted. Pending review and discussion.