### PR TITLE
Move parameterized from install_requires to extras_require[dev]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             uv venv --python 3.12 /usr/local/share/virtualenvs/tap-quickbase
             source /usr/local/share/virtualenvs/tap-quickbase/bin/activate
             uv pip install -U pip setuptools
-            uv pip install .
+            uv pip install .[dev]
       - run:
           name: 'pylint'
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.1
+  * Bump requests to 2.33.0 (CVE-2026-25645)
+
 # Changelog
 
 ## 3.0.0

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ setup(name="tap-quickbase",
         "singer-python==6.8.0",
         "requests==2.32.5",
         "backoff==2.2.1",
-        "parameterized==0.9.0"
       ],
       extras_require={
         "dev": [
+          "parameterized==0.9.0",
           "pytest",
           "coverage"
         ]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="tap-quickbase",
-      version="3.0.0",
+      version="3.0.1",
       description="Singer.io tap for extracting data from Quickbase API",
       author="Stitch",
       url="http://singer.io",
@@ -12,7 +12,7 @@ setup(name="tap-quickbase",
       py_modules=["tap_quickbase"],
       install_requires=[
         "singer-python==6.8.0",
-        "requests==2.32.5",
+        "requests==2.33.0",
         "backoff==2.2.1",
       ],
       extras_require={


### PR DESCRIPTION
## Summary

`parameterized` is only used in test files and should not be included in the production image.

This moves it to `extras_require[dev]` and updates CI to install `.[dev]` so tests still have the dependency available.